### PR TITLE
Add compability code to broaden platform support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,10 @@ nb            = "1.0.0"
 paste         = "1.0.3"
 ramp-maker    = "0.2.0"
 
+[dependencies.embedded-hal-stable]
+version = "0.2.4"
+package = "embedded-hal"
+
 [dependencies.num-traits]
 version          = "0.2.14"
 default-features = false

--- a/documentation/platform-support.md
+++ b/documentation/platform-support.md
@@ -74,7 +74,7 @@ This is not that easy (and can in fact get quite complicated, if the timer frequ
 
 If adding the required trait implementations directly in the HAL is not practical for some reason, you can work around this by providing these implementations in your own code. While it is not possible to implement a foreign trait for a foreign type ("foreign" as in "defined in another crate"), you can create your own wrapper types, and implement the required traits for them.
 
-There is an [open pull request](https://github.com/flott-motion/stepper/pull/122) that aims to provide these wrappers as part of Stepper. It is currently blocked and can't be merged right now, unfortunately, but it can serve as an example to model your own wrapper types after.
+The `compat` module in Stepper provides such wrappers.
 
 
 [LPC845]: https://www.nxp.com/products/processors-and-microcontrollers/arm-microcontrollers/general-purpose-mcus/lpc800-cortex-m0-plus-/low-cost-microcontrollers-mcus-based-on-arm-cortex-m0-plus-cores:LPC84X

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -1,0 +1,113 @@
+//! Compatibility code to help use Stepper on more platforms
+
+use core::convert::{Infallible, TryFrom};
+
+use embedded_hal::{digital::OutputPin, timer::CountDown};
+use embedded_hal_stable::{
+    digital::v2::OutputPin as StableOutputPin,
+    timer::CountDown as StableCountDown,
+};
+use embedded_time::{
+    duration::Duration as _, rate::Fraction, ConversionError, TimeInt,
+};
+
+/// Wrapper around a pin
+///
+/// Provides an implementation of [`embedded_hal::digital::OutputPin`] (that is,
+/// the `OutputPin` from the latest alpha version of `embedded-hal`) for all
+/// types that implement `OutputPin` from the latest stable version of
+/// `embedded-hal`.
+pub struct Pin<T>(pub T);
+
+impl<T> OutputPin for Pin<T>
+where
+    T: StableOutputPin,
+{
+    type Error = <T as StableOutputPin>::Error;
+
+    fn try_set_low(&mut self) -> Result<(), Self::Error> {
+        self.0.set_low()
+    }
+
+    fn try_set_high(&mut self) -> Result<(), Self::Error> {
+        self.0.set_high()
+    }
+}
+
+/// Wrapper around a timer
+///
+/// Provides an implementation of [`embedded_hal::timer::CountDown`] (that is,
+/// the `CountDown` from the latest alpha version of `embedded-hal`) for all
+/// types that implement `CountDown` from the latest stable version of
+/// `embedded-hal`.
+pub struct Timer<T, const FREQ: u32>(pub T);
+
+impl<T, const FREQ: u32> CountDown for Timer<T, FREQ>
+where
+    T: StableCountDown,
+{
+    type Error = Infallible;
+
+    type Time = Ticks<<T as StableCountDown>::Time, FREQ>;
+
+    fn try_start<Ticks>(&mut self, ticks: Ticks) -> Result<(), Self::Error>
+    where
+        Ticks: Into<Self::Time>,
+    {
+        let ticks = ticks.into();
+        self.0.start(ticks.0);
+        Ok(())
+    }
+
+    fn try_wait(&mut self) -> nb::Result<(), Self::Error> {
+        match self.0.wait() {
+            Ok(()) => Ok(()),
+            Err(nb::Error::WouldBlock) => return Err(nb::Error::WouldBlock),
+            Err(nb::Error::Other(_)) => {
+                unreachable!("Caught error from infallible method")
+            }
+        }
+    }
+}
+
+/// Timer ticks for a timer with frequency `FREQ`
+///
+/// Provides conversions from various duration types from `embedded-time` into
+/// timer ticks for a timer with the frequency defined by `FREQ`. Since this is
+/// a fully generic type that has no knowledge of the timers it is being used
+/// with, it is the user's responsibility to make sure the resulting value is
+/// valid for the timer.
+///
+/// `FREQ` is defined in Hz.
+pub struct Ticks<T, const FREQ: u32>(pub T);
+
+macro_rules! impl_conversions {
+    ($($duration:ident,)*) => {
+        $(
+            impl<T, const FREQ: u32> TryFrom<embedded_time::duration::$duration>
+                for Ticks<T, FREQ>
+            where
+                T: TimeInt,
+            {
+                type Error = ConversionError;
+
+                fn try_from(duration: embedded_time::duration::$duration)
+                    -> Result<Self, Self::Error>
+                {
+                    let ticks =
+                        duration.to_generic::<T>(Fraction::new(1, FREQ))?;
+                    Ok(Self(*ticks.integer()))
+                }
+            }
+        )*
+    };
+}
+
+impl_conversions!(
+    Nanoseconds,
+    Microseconds,
+    Milliseconds,
+    Seconds,
+    Minutes,
+    Hours,
+);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,7 @@ pub extern crate embedded_hal;
 pub extern crate embedded_time;
 pub extern crate ramp_maker;
 
+pub mod compat;
 pub mod drivers;
 pub mod motion_control;
 pub mod step_mode;


### PR DESCRIPTION
This is currently blocked on https://github.com/FluenTech/embedded-time/pull/101 and a new release of `embedded-time`.